### PR TITLE
Comparing dispatch_get_current_queue() with dispatch_get_main_queue()…

### DIFF
--- a/algorithms-iOS/algorithms-iOS/TXSubThreadMOC.m
+++ b/algorithms-iOS/algorithms-iOS/TXSubThreadMOC.m
@@ -15,7 +15,7 @@
 
 - (NSManagedObjectContext *)mocInitedOnSubThread {
   
-  NSAssert(dispatch_get_current_queue() != dispatch_get_main_queue(), @"This method should not be called from main queue");
+  NSAssert(![NSThread isMainThread], @"This method should not be called from main queue");
   
   if (mocInitedOnSubThread != nil) {
     return mocInitedOnSubThread;


### PR DESCRIPTION
… is not only deprecated since iOS6, but unreliable according to queue.h

When dispatch_get_current_queue() is called on the main thread, it may or may not return the same value as dispatch_get_main_queue(). Comparing the two is not a valid way to test whether code is executing on the main thread.
